### PR TITLE
[ing-diba] parse number over 1000 correctly

### DIFF
--- a/packages/ynap-parsers/src/de/ing-diba/ing-diba.spec.ts
+++ b/packages/ynap-parsers/src/de/ing-diba/ing-diba.spec.ts
@@ -18,7 +18,9 @@ In der CSV-Datei finden Sie alle bereits gebuchten Umsätze. Die vorgemerkten Um
 
 Buchung;Valuta;Auftraggeber/Empfänger;Buchungstext;Verwendungszweck;Betrag;Währung
 03.04.2019;03.04.2019;eprimo GmbH;Lastschrift;eprimo sagt danke;-71,00;EUR
-03.04.2019;03.04.2019;Income;Gehalt/Rente;MAERZ 2019;700,00;EUR`,
+03.04.2019;03.04.2019;Income;Gehalt/Rente;MAERZ 2019;700,00;EUR
+03.04.2020;03.04.2020;Income;Gehalt/Rente;MAERZ 2020;1.700,00;EUR
+03.04.2020;03.04.2020;Thousand Euros gone;Lastschrift;Thank you;-1.000,00;EUR`,
   'win1252',
 );
 
@@ -38,6 +40,20 @@ const ynabResult: YnabFile[] = [
         Memo: 'MAERZ 2019',
         Outflow: undefined,
         Inflow: '700.00',
+      },
+      {
+        Date: '04/03/2020',
+        Payee: 'Income',
+        Memo: 'MAERZ 2020',
+        Outflow: undefined,
+        Inflow: '1700.00',
+      },
+      {
+        Date: '04/03/2020',
+        Payee: 'Thousand Euros gone',
+        Memo: 'Thank you',
+        Outflow: '1000.00',
+        Inflow: undefined,
       },
     ],
   },

--- a/packages/ynap-parsers/src/de/ing-diba/ing-diba.ts
+++ b/packages/ynap-parsers/src/de/ing-diba/ing-diba.ts
@@ -24,7 +24,7 @@ export const generateYnabDate = (input: string) => {
   return [month.padStart(2, '0'), day.padStart(2, '0'), year].join('/');
 };
 
-export const parseNumber = (input: string) => Number(input.replace(',', '.'));
+export const parseNumber = (input: string) => Number(input.replace('.','').replace(',', '.'));
 
 export const trimMetaData = (input: string) =>
   input.substr(input.indexOf('Buchung;'));


### PR DESCRIPTION
The amount number in ING Diba Csv files are in the format "1.000,00".

In the parseNumber it will only replace the commas, resulting in "1.000.00", that produces an error and no number will be returned.

to fix it, replace first all dots to empty string, and than convert commas to dots