### PR TITLE
fix: comdirect parsing of "offen" transactions

### DIFF
--- a/packages/ynap-parsers/src/de/comdirect/comdirect.spec.ts
+++ b/packages/ynap-parsers/src/de/comdirect/comdirect.spec.ts
@@ -13,6 +13,7 @@ const content = encode(
 "Neuer Kontostand";"16,94 EUR";
 
 "Buchungstag";"Wertstellung (Valuta)";"Vorgang";"Buchungstext";"Umsatz in EUR";
+"offen";"--";"Kartenverfügung";"Kto/IBAN: 000000000000  Buchungstext: NETFLIX.COM Berlin DE               2021-01-01T00:00:00                 ";"-15,99";
 "01.04.2019";"03.04.2019";"Wertpapiere";" Buchungstext: ISHSII-MSCI EUR.SRI EOACC WPKNR: A1H7ZS ISIN: IE00B52VJ196 Ref. 25F1909221559359/2 ";"-119,98";
 "01.04.2019";"01.04.2019";"DTA-glt. Buchung";" Zahlungspflichtiger: John DoeKto/IBAN: DE84100110012626835902 BLZ/BIC: NTSBDEB1XXX Buchungstext: Sparplan 1 Ref. H9219087I4644658/2 ";"180,00";
 
@@ -21,6 +22,7 @@ const content = encode(
 );
 
 const trimmedContent = `"Buchungstag";"Wertstellung (Valuta)";"Vorgang";"Buchungstext";"Umsatz in EUR";
+"offen";"--";"Kartenverfügung";"Kto/IBAN: 000000000000  Buchungstext: NETFLIX.COM Berlin DE               2021-01-01T00:00:00                 ";"-15,99";
 "01.04.2019";"03.04.2019";"Wertpapiere";" Buchungstext: ISHSII-MSCI EUR.SRI EOACC WPKNR: A1H7ZS ISIN: IE00B52VJ196 Ref. 25F1909221559359/2 ";"-119,98";
 "01.04.2019";"01.04.2019";"DTA-glt. Buchung";" Zahlungspflichtiger: John DoeKto/IBAN: DE84100110012626835902 BLZ/BIC: NTSBDEB1XXX Buchungstext: Sparplan 1 Ref. H9219087I4644658/2 ";"180,00";`;
 

--- a/packages/ynap-parsers/src/de/comdirect/comdirect.ts
+++ b/packages/ynap-parsers/src/de/comdirect/comdirect.ts
@@ -84,7 +84,7 @@ export const comdirectParser: ParserFunction = async (file: File) => {
   return [
     {
       data: (data as ComdirectRow[])
-        .filter(r => r.Buchungstag && r['Umsatz in EUR'])
+        .filter(r => r.Buchungstag && r.Buchungstag != "offen" && r['Umsatz in EUR'])
         .map(r => ({
           Date: generateYnabDate(r.Buchungstag),
           Payee:


### PR DESCRIPTION
comdirect reports transactions that are known, but not yet booked with a `Buchungsdatum` of `offen`.
YNAP tries to parse these, which expectably fails.

As these cannot be parsed correctly, with this commit those lines are ignored.
